### PR TITLE
add validations to delete and list

### DIFF
--- a/src/modules/question/controllers/delete.question.controller.ts
+++ b/src/modules/question/controllers/delete.question.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Delete, Get, Inject, Param, ParseArrayPipe, ParseIntPipe, Query } from '@nestjs/common';
+import { Delete, Param, ParseIntPipe } from '@nestjs/common';
+import { DeleteQuestionDto } from '../dto/delete.question.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AuthController } from 'src/utils/decorators/auth-controller.decorator';
 import { Repository } from 'typeorm';
@@ -12,9 +13,11 @@ export class DeleteQuestionController {
   ) {}
 
   @Delete(':id')
-  async handler(@Param('id') id: string) {
-
-    await this.questionRepository.delete(id)      
+  async handler(
+    @Param('id', ParseIntPipe)
+    id: DeleteQuestionDto,
+  ) {
+    await this.questionRepository.delete(id);
 
     return true;
   }

--- a/src/modules/question/controllers/list.question.controller.ts
+++ b/src/modules/question/controllers/list.question.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Inject, ParseArrayPipe, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, ParseArrayPipe, Query } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Question } from '../domain';
@@ -11,20 +11,27 @@ export class ListQuestionController {
   ) {}
 
   @Get('')
-  async handler(@Query('apps', new ParseArrayPipe({ optional: true })) apps = []) {
-
+  async handler(
+    @Query(
+      'apps',
+      new ParseArrayPipe({ items: Number, separator: ',', optional: true }),
+    )
+    apps = [],
+  ) {
     const query = this.questionRepository
       .createQueryBuilder('question')
-      .leftJoinAndSelect("question.apps", "apps")
-      .leftJoinAndSelect("question.explanations", "explanations")
-      .take(10)
-      
-    // console.log("🚀 ~ file: list.question.controller.ts:23 ~ ListQuestionController ~ handler ~ apps", apps)
-    // if (apps.length > 0) {
-    //   query.where('apps.id IN(:...ids)', {ids: apps})
-    // }
-    const response = await query.getMany()
+      .leftJoinAndSelect('question.apps', 'apps')
+      .leftJoinAndSelect('question.explanations', 'explanations')
+      .take(10);
 
+    console.log(
+      '🚀 ~ file: list.question.controller.ts:23 ~ ListQuestionController ~ handler ~ apps',
+      apps,
+    );
+    if (apps.length > 0) {
+      query.where('apps.id IN(:...ids)', { ids: apps });
+    }
+    const response = await query.getMany();
 
     return response;
   }

--- a/src/modules/question/dto/delete.question.dto.ts
+++ b/src/modules/question/dto/delete.question.dto.ts
@@ -1,0 +1,6 @@
+import { IsNumberString } from 'class-validator';
+
+export class DeleteQuestionDto {
+  @IsNumberString()
+  id: number;
+}


### PR DESCRIPTION
### Changes

- `/question` get endpoint will only accept numeric values on the params. If you test it with a param like this:
```
http://localhost:3000/question?apps=select * from users;
```
it will return a 401 error

- `/question` delete endpoint will only accept a numeric value on the id